### PR TITLE
Start implementing SongManager to replace beat_scroller.

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -4,9 +4,8 @@ using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-    public AudioSource theMusic;
-    public bool startPlaying;
-    public beat_scroller beatScroller; //this controls the beat scroller. we want to access it, so we create a ref point for it
+    public bool startPlaying = true;
+    //public beat_scroller beatScroller; //this controls the beat scroller. we want to access it, so we create a ref point for it
 
     public static GameManager instance; //instance of game manager *all notes* refer to.
 
@@ -18,14 +17,6 @@ public class GameManager : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
-        if(!startPlaying){
-            if(Input.anyKeyDown){
-                startPlaying = true;
-                beatScroller.hasStarted = true;
-                theMusic.Play();
-            }
-        }
 
     }
 

--- a/Assets/Scripts/NoteObject.cs
+++ b/Assets/Scripts/NoteObject.cs
@@ -7,8 +7,13 @@ using UnityEngine;
 public class NoteObject : MonoBehaviour
 {
     public bool canBePressed; 
-
     public KeyCode keyToPress;
+
+    public float spawnPos;  //spawn line
+    public float removePos; //remove line
+    public float beatOfThisNote;
+
+    public SongManager song;
 
     void Start()
     {
@@ -21,28 +26,30 @@ public class NoteObject : MonoBehaviour
         if(Input.GetKeyDown(keyToPress)){
             if(canBePressed){
                 gameObject.SetActive(false);
-
                 GameManager.instance.NoteHit(); //tell game manager, hey we hit a note! 
             }
         }
+
+        transform.position = Vector2.Lerp(
+            spawnPos,
+            removePos,
+            (song.beatsShownInAdvance - (beatOfThisNote - song.songPositionInBeats)) / song.beatsShownInAdvance
+        );
+
     }
 
+    //If you collide with target (targets have tag activator), announce you've been hit.
     private void OnTriggerEnter2D(Collider2D other){
-
         if(other.tag == "Activator"){
             canBePressed = true;
         }
-
     }
 
+    //If you collide with target (targets have tag activator), announce you've been hit.
     private void OnTriggerExit2D(Collider2D other){
-
         if(other.tag == "Activator"){
             canBePressed = false;
-
             GameManager.instance.NoteMissed(); //tell game manager, hey, we missed this note.
         }
-
     }
-
 }

--- a/Assets/Scripts/SongManager.cs
+++ b/Assets/Scripts/SongManager.cs
@@ -1,0 +1,85 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//Replaces beat_scroller
+
+public class SongManager : MonoBehaviour
+{
+
+    //Song information and position for synced actions.
+   
+    public float songPosition;      //song position in seconds
+    public float songPositionInBeats; //song position in beats
+    public float dspSongTime; //displacement - how many  seconds have passed since song started
+    
+    public AudioSource musicSource;
+    public float songBPM;   //beats per minute
+    public float secPerBeat; //seconds per beat
+    public float beginOffset = 0; //silence/song interlude, before gameplay begins.
+    
+    /**TODO: max number of beats you can show on screen at once?
+    for those sick beat drops, you need a LOOOOT of notes!~*/
+    public int beatsShownInAdvance = 25; 
+
+    //all the positions (in beats) of notes in the song.
+    //**TODO: try this as a nested array instead?*/
+    public float[] topNotes;
+    public float[] botNotes;
+
+    //index of the next note to be spawned, tranversing the array of notes.
+    //++ whenever a note is spawned.
+    public int topNextIndex = 0;
+    public int botNextIndex = 0;
+    
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        //Load audiosource for this SongManager GameObject.
+        musicSource = GetComponent<AudioSource>();
+
+        //Calculate the # of seconds per beat.
+        secPerBeat = 60f / songBPM;
+
+        //Mark when the song starts. 
+        dspSongTime = (float) AudioSettings.dspTime;
+
+        /**TODO: remove/change when implementing cutscene.
+        until then, play immediately upon starting scene.*/
+        musicSource.Play();
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        //Determine elapsed TIME since song started.
+        songPosition = (float) (AudioSettings.dspTime - dspSongTime - beginOffset);
+
+        //Determine elapsed BEATS since song started
+        songPositionInBeats = songPosition / secPerBeat;
+
+
+        //Initialize the next music notes
+        if(botNextIndex < botNotes.Length && botNotes[botNextIndex] < songPositionInBeats + beatsShownInAdvance){
+            //initialize music note prefab
+
+            //initialize music note fields 
+
+            botNextIndex++;
+        }
+
+        if(topNextIndex < topNotes.Length && topNotes[topNextIndex] < songPositionInBeats + beatsShownInAdvance){
+            //initialize music note prefab
+
+            //initialize music note fields 
+
+            topNextIndex++;
+        }
+
+
+        /*note: the MUSIC NOTES update() control their movement, not the songmanager.*/
+
+    }
+}

--- a/Assets/Scripts/SongManager.cs.meta
+++ b/Assets/Scripts/SongManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d56f1d4a1207c614f8470b6e46847640
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
beat_scroller is now defunct! SongManager handles a song's information and position over time. Also contains an array of the position (in beats) of notes in the song (rn as top and bot lanes, but these should be put into a nested notes[]).

Also NoteObject transforms the note position, not SongManager. 

This does not work and has not been tested (oops - I'll do that later)